### PR TITLE
Remove auth and allow demo without login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import Dashboard from './pages/Dashboard';
@@ -9,70 +9,19 @@ import TeamPage from './pages/TeamPage';
 import SettingsPage from './pages/SettingsPage';
 import GeneratePlanPage from './pages/GeneratePlanPage';
 import ReviewPage from './pages/ReviewPage';
-import PrivateRoute from './components/PrivateRoute';
 
 function AppContent() {
-  const { isAuthenticated } = useAuth();
 
   return (
     <Routes>
-      <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" /> : <LoginPage />} />
-      <Route path="/register" element={isAuthenticated ? <Navigate to="/dashboard" /> : <RegisterPage />} />
-      <Route
-        path="/dashboard"
-        element={
-          <PrivateRoute>
-            <Dashboard />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/plans"
-        element={
-          <PrivateRoute>
-            <PlansPage />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/generate-plan"
-        element={
-          <PrivateRoute>
-            <GeneratePlanPage />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/team"
-        element={
-          <PrivateRoute>
-            <TeamPage />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/settings"
-        element={
-          <PrivateRoute>
-            <SettingsPage />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/review"
-        element={
-          <PrivateRoute>
-            <ReviewPage />
-          </PrivateRoute>
-        }
-      />
-      {/* Temporary dev routes - bypass authentication */}
-      <Route path="/dashboard-dev" element={<Dashboard />} />
-      <Route path="/plans-dev" element={<PlansPage />} />
-      <Route path="/team-dev" element={<TeamPage />} />
-      <Route path="/settings-dev" element={<SettingsPage />} />
-      <Route path="/generate-plan-dev" element={<GeneratePlanPage />} />
-      <Route path="/review-dev" element={<ReviewPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/plans" element={<PlansPage />} />
+      <Route path="/generate-plan" element={<GeneratePlanPage />} />
+      <Route path="/team" element={<TeamPage />} />
+      <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/review" element={<ReviewPage />} />
       <Route path="/" element={<LandingPage />} />
     </Routes>
   );

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,19 +1,13 @@
-import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
+// This component previously handled authentication checks.
+// Authentication has been disabled for demo purposes so it
+// simply renders its children.
 
 interface PrivateRouteProps {
   children: React.ReactNode;
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
-  const { isAuthenticated } = useAuth();
-  const location = useLocation();
-
-  return isAuthenticated ? (
-    <>{children}</>
-  ) : (
-    <Navigate to="/login" state={{ from: location.pathname, requireAuth: true }} replace />
-  );
+  return <>{children}</>;
 };
 
 export default PrivateRoute;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import type { ReactNode } from 'react';
 
 interface AuthContextType {
@@ -24,26 +24,16 @@ interface AuthProviderProps {
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [token, setToken] = useState<string | null>(null);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  useEffect(() => {
-    const storedToken = localStorage.getItem('token');
-    if (storedToken) {
-      setToken(storedToken);
-      setIsAuthenticated(true);
-    }
-  }, []);
+  // Authentication is disabled for demo purposes, so pages are always accessible
+  const isAuthenticated = true;
 
   const login = (newToken: string) => {
-    localStorage.setItem('token', newToken);
     setToken(newToken);
-    setIsAuthenticated(true);
   };
 
   const logout = () => {
-    localStorage.removeItem('token');
     setToken(null);
-    setIsAuthenticated(false);
   };
 
   return (

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from 'react-router-dom';
-import LoginForm from '../components/Auth/LoginForm';
+import { useLocation, Link } from 'react-router-dom';
+import Button from '../components/ui/Button';
 import Logo from '../components/ui/Logo';
 
 const LoginPage = () => {
@@ -53,7 +53,11 @@ const LoginPage = () => {
             </div>
 
             <div className="mt-10">
-              <LoginForm />
+              <Link to="/dashboard">
+                <Button variant="brand" className="w-full" size="lg">
+                  View Dashboard
+                </Button>
+              </Link>
             </div>
             
             <p className="mt-10 text-center text-xs text-gray-400">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,30 +4,7 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000',
 });
 
-api.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-api.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('token');
-      window.location.href = '/login';
-    }
-    return Promise.reject(error);
-  }
-);
+// Authentication has been removed for the demo build, so no
+// interceptors are required here.
 
 export default api;


### PR DESCRIPTION
## Summary
- disable auth mechanisms in AuthContext
- simplify PrivateRoute to render children
- remove auth checks from routing and drop dev-only routes
- turn login page into a link to the dashboard
- strip auth-related axios interceptors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686eefab38b48324b23f8770319f24bf